### PR TITLE
Add automated tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
 target
+.idea

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,22 @@
+stages:
+  - build
+  - test
+
+build-package:
+  stage: build
+  tags:
+    - matlab-R2017b
+  script:
+    - mvn install
+  artifacts:
+    paths:
+      - target/*.zip
+      - target/*.tar.gz
+
+test-package:
+  stage: test
+  tags:
+    - matlab-R2017b
+  script:
+    - PATH=/usr/local/MATLAB/R2017b/bin:$PATH
+    - mvn -P test-matlab

--- a/pom.xml
+++ b/pom.xml
@@ -23,6 +23,9 @@
          When possible, we advise using the relevant groupId and version
          properties for your dependencies rather than hardcoding them. -->
 
+    <test.output.dir>${basedir}/target/matlab-test-results</test.output.dir>
+    <test.output>${test.output.dir}/report.xml</test.output>
+
     <date>${maven.build.timestamp}</date>
     <year>2018</year>
     <project.rootdir>${basedir}</project.rootdir>
@@ -313,6 +316,25 @@
             </executions>
           </plugin>
           <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-antrun-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>create-test-output-dir</id>
+                <phase>test</phase>
+                <configuration>
+                  <tasks>
+                    <delete dir="${test.output.dir}"/>
+                    <mkdir dir="${test.output.dir}"/>
+                  </tasks>
+                </configuration>
+                <goals>
+                  <goal>run</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
             <groupId>org.codehaus.mojo</groupId>
             <artifactId>exec-maven-plugin</artifactId>
             <version>1.6.0</version>
@@ -329,13 +351,13 @@
               <executable>matlab</executable>
               <workingDirectory>${java.io.tmpdir}</workingDirectory>
               <environmentVariables>
-                <MATLABPATH>${project.build.directory}/test-matlab/bio-formats-matlab-${project.version}</MATLABPATH>
+                <MATLABPATH>${project.build.directory}/test-matlab/bio-formats-matlab-${project.version}${path.separator}${basedir}/test</MATLABPATH>
               </environmentVariables>
               <arguments>
                 <argument>-nodesktop</argument>
                 <argument>-nosplash</argument>
                 <argument>-r</argument>
-                <argument>runtests ${project.rootdir}/test</argument>
+                <argument>runbfxunit ${test.output}</argument>
               </arguments>
             </configuration>
           </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>
-        <version>3.0.0-M1</version>
+        <version>3.0.0-M2</version>
         <executions>
           <execution>
             <id>enforce-maven</id>
@@ -73,11 +73,6 @@
       </plugin>
       <plugin>
         <artifactId>maven-clean-plugin</artifactId>
-        <version>3.0.0</version>
-      </plugin>
-
-      <plugin>
-        <artifactId>maven-dependency-plugin</artifactId>
         <version>3.1.0</version>
       </plugin>
 
@@ -93,7 +88,7 @@
 
       <plugin>
         <artifactId>maven-plugin-plugin</artifactId>
-        <version>3.5.1</version>
+        <version>3.5.2</version>
       </plugin>
 
       <plugin>
@@ -110,7 +105,12 @@
 
       <plugin>
         <artifactId>maven-resources-plugin</artifactId>
-        <version>3.0.2</version>
+        <version>3.1.0</version>
+      </plugin>
+
+      <plugin>
+        <artifactId>maven-site-plugin</artifactId>
+        <version>3.7.1</version>
       </plugin>
 
       <plugin>
@@ -139,6 +139,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
+        <version>3.1.1</version>
         <executions>
           <execution>
             <id>unpack-ome-xml</id>
@@ -292,7 +293,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-dependency-plugin</artifactId>
-            <version>3.0.2</version>
+            <version>3.1.1</version>
             <executions>
               <execution>
                 <id>unpack</id>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>ome</groupId>
   <artifactId>bio-formats-matlab</artifactId>
-  <version>5.8.1-SNAPSHOT</version>
+  <version>5.8.2</version>
   <packaging>pom</packaging>
 
   <name>Bio-Formats bundle collection</name>
@@ -26,7 +26,7 @@
     <date>${maven.build.timestamp}</date>
     <year>2018</year>
     <project.rootdir>${basedir}</project.rootdir>
-    <bioformats.version>5.8.1-SNAPSHOT</bioformats.version>
+    <bioformats.version>5.8.2</bioformats.version>
     <bio-formats_package.version>${bioformats.version}</bio-formats_package.version>
     <imagej1.version>1.48s</imagej1.version>
     <log4j.version>1.2.17</log4j.version>

--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
 
       <plugin>
         <artifactId>maven-dependency-plugin</artifactId>
-        <version>3.0.2</version>
+        <version>3.1.0</version>
       </plugin>
 
       <plugin>
@@ -318,6 +318,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-antrun-plugin</artifactId>
+            <version>1.8</version>
             <executions>
               <execution>
                 <id>create-test-output-dir</id>

--- a/pom.xml
+++ b/pom.xml
@@ -10,8 +10,8 @@
   <version>5.8.2</version>
   <packaging>pom</packaging>
 
-  <name>Bio-Formats bundle collection</name>
-  <description>Create matlab of Bio-Formats jars and tools for distribution.</description>
+  <name>Bio-Formats matlab package</name>
+  <description>Create matlab package of Bio-Formats jars and tools for distribution.</description>
   <url>https://www.openmicroscopy.org/bio-formats</url>
   <inceptionYear>2005</inceptionYear>
 

--- a/test/ReaderTest.m
+++ b/test/ReaderTest.m
@@ -26,7 +26,7 @@
 % 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 classdef ReaderTest < TestBfMatlab
-    
+
     properties
         reader
         sizeX
@@ -35,14 +35,9 @@ classdef ReaderTest < TestBfMatlab
         sizeC
         sizeT
     end
-    
-    methods
-        function self = ReaderTest(name)
-            self = self@TestBfMatlab(name);
-        end
-        
-        function setUp(self)
-            setUp@TestBfMatlab(self)
+
+    methods (TestMethodSetup)
+        function ReaderTestSetUp(self)
             javaaddpath(self.jarPath);
             self.reader = loci.formats.in.FakeReader();
             self.sizeX = self.reader.DEFAULT_SIZE_X;
@@ -53,13 +48,14 @@ classdef ReaderTest < TestBfMatlab
             loci.common.DebugTools.setRootLevel('ERROR');
             import ome.units.UNITS.*;
         end
-        
-        function tearDown(self)
+    end
+
+    methods (TestMethodTeardown)
+        function ReaderTestTearDown(self)
             if ~isempty(self.reader),
                 self.reader.close();
                 self.reader = [];
             end
-            tearDown@TestBfMatlab(self)
         end
     end
 end

--- a/test/TestBfCheckJavaMemory.m
+++ b/test/TestBfCheckJavaMemory.m
@@ -26,48 +26,46 @@
 % 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 classdef TestBfCheckJavaMemory < TestBfMatlab
-    
+
     properties
         minMemory
         warning_id = ''
     end
-    
+
     methods
-        function self = TestBfCheckJavaMemory(name)
-            self = self@TestBfMatlab(name);
-        end
-        
         % Dimension size tests
         function runJavaMemoryCheck(self)
             lastwarn('');
             bfCheckJavaMemory(self.minMemory)
             [last_warning_msg, last_warning_id] = lastwarn;
-            assertEqual(last_warning_id, self.warning_id);
+            self.assertEqual(last_warning_id, self.warning_id);
             lastwarn('');
         end
-        
+    end
+
+    methods (Test)
         function testZero(self)
             self.minMemory = 0;
             self.runJavaMemoryCheck()
         end
-        
+
         function testMaxMemory(self)
             self.minMemory = self.getRuntime();
             self.runJavaMemoryCheck()
         end
-        
+
         function testLowMemory(self)
             self.minMemory = round(self.getRuntime() + 100);
             self.warning_id = 'BF:lowJavaMemory';
             self.runJavaMemoryCheck()
         end
     end
+
     methods(Static)
-        
         function memory = getRuntime()
             runtime = java.lang.Runtime.getRuntime();
             memory = runtime.maxMemory() / (1024 * 1024);
         end
     end
-    
+
 end

--- a/test/TestBfCheckJavaPath.m
+++ b/test/TestBfCheckJavaPath.m
@@ -27,39 +27,37 @@
 
 
 classdef TestBfCheckJavaPath < TestBfMatlab
-    
+
     properties
         status
         version
         maxTime = .1
     end
-    
-    methods
-        function self = TestBfCheckJavaPath(name)
-            self = self@TestBfMatlab(name);
-        end
-        
+
+    methods (Test)
         function testDefault(self)
+            javaaddpath(self.jarPath);
             self.status = bfCheckJavaPath();
-            assertTrue(self.status);
+            self.assertTrue(self.status);
         end
-        
+
         function testAutoloadBioformats(self)
+            javaaddpath(self.jarPath);
             self.status = bfCheckJavaPath(true);
-            assertTrue(self.status);
+            self.assertTrue(self.status);
         end
-        
+
         function testNoAutoloadBioformats(self)
             isStatic = ismember(self.jarPath,...
                 javaclasspath('-static'));
             self.status = bfCheckJavaPath(false);
             if isStatic
-                assertTrue(self.status);
+                self.assertTrue(self.status);
             else
-                assertFalse(self.status);
+                self.assertFalse(self.status);
             end
         end
-        
+
         function testPerformance(self)
             nCounts = 10;
             times = zeros(nCounts);
@@ -68,27 +66,28 @@ classdef TestBfCheckJavaPath < TestBfMatlab
                 bfCheckJavaPath();
                 times(i) = toc;
             end
-            
+
             % First call should be the longest as the Bio-Formats JAR file is
             % added to the javaclasspath
-            assertTrue(times(1) > times(2));
+            self.assertTrue(times(1) > times(2));
             % Second call should still be longer than all the following
             % ones. Profiling reveals some amount of time is spent while
             % computing javaclasspath.local_get_static_path
-            assertTrue(all(times(2) > times(3:end)));
+            self.assertTrue(all(times(2) > times(3:end)));
             % From the third call and onwards, javaclasspath and thus
             % bfCheckJavaPath should return fast
-            assertTrue(mean(times(3:end)) < self.maxTime);
+            self.assertTrue(mean(times(3:end)) < self.maxTime);
         end
-        
+
         function testJavaMethod(self)
+            javaaddpath(self.jarPath);
             self.status = bfCheckJavaPath(true);
             version = char(loci.formats.FormatTools.VERSION);
             [self.status self.version]= bfCheckJavaPath(false);
-            assertEqual(self.version,version);
+            self.assertEqual(self.version,version);
             if (exist ('OCTAVE_VERSION', 'builtin'))
                 version = char(java_get('loci.formats.FormatTools', 'VERSION'));
-                assertEqual( self.version, version);
+                self.assertEqual( self.version, version);
             end
         end
     end

--- a/test/TestBfGetPlane.m
+++ b/test/TestBfGetPlane.m
@@ -26,7 +26,7 @@
 % 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 classdef TestBfGetPlane < ReaderTest
-    
+
     properties
         iPlane = 1
         x
@@ -37,134 +37,134 @@ classdef TestBfGetPlane < ReaderTest
         sgn
         fp
     end
-    
-    methods
-        function self = TestBfGetPlane(name)
-            self = self@ReaderTest(name);
-        end
-        
-        function setUp(self)
-            setUp@ReaderTest(self)
+
+    methods (TestMethodSetup)
+        function GetPlaneSetUp(self)
             self.reader.setId('test.fake');
             self.x = 1;
             self.y = 1;
             self.width = self.sizeX;
             self.height = self.sizeY;
         end
-        
-        % Input check tests
-        function testNoInput(self)
-            assertExceptionThrown(@() bfGetPlane(), 'MATLAB:minrhs');
-        end
-        
-        function testReaderClass(self)
-            assertExceptionThrown(@() bfGetPlane([]),...
-                'MATLAB:InputParser:ArgumentFailedValidation');
-        end
-        
-        function testInvalidReader(self)
-            self.reader.close();
-            assertExceptionThrown(@() bfGetPlane(self.reader),...
-                'MATLAB:InputParser:ArgumentFailedValidation');
-        end
-        
-        function testNoInputPlane(self)
-            f = @() bfGetPlane(self.reader);
-            assertExceptionThrown(f, 'MATLAB:InputParser:notEnoughInputs');
-        end
-        
-        function checkInvalidInput(self)
-            f = @() bfGetPlane(self.reader, self.iPlane);
-            assertExceptionThrown(f,...
-                'MATLAB:InputParser:ArgumentFailedValidation');
-        end
-        
-        function testZeroPlane(self)
-            assertExceptionThrown(@() bfGetPlane(self.reader, 0),...
-                'MATLAB:InputParser:ArgumentFailedValidation');
-        end
-        
-        function testOversizedPlaneIndex(self)
-            nmax = self.reader.getImageCount();
-            assertExceptionThrown(@() bfGetPlane(self.reader, nmax + 1),...
-                'MATLAB:InputParser:ArgumentFailedValidation');
-        end
-        
-        function testPlaneIndexArray(self)
-            assertExceptionThrown(@() bfGetPlane(self.reader, [1 1]),...
-                'MATLAB:InputParser:ArgumentFailedValidation');
-        end
-        
+    end
+
+    methods
         %% Tile input tests
         function checkInvalidTileInput(self, varargin)
             f = @() bfGetPlane(self.reader, 1, varargin{:});
-            assertExceptionThrown(f,...
+            self.assertError(f,...
                 'MATLAB:InputParser:ArgumentFailedValidation');
         end
-        
-        function testZeroTileX(self)
-            self.x = 0;
-            self.checkInvalidTileInput(self.x)
+
+        function checkInvalidInput(self)
+            f = @() bfGetPlane(self.reader, self.iPlane);
+            self.assertError(f,...
+                'MATLAB:InputParser:ArgumentFailedValidation');
         end
-        
-        function testOversizedTileX(self)
-            self.x = self.sizeX + 1;
-            self.checkInvalidTileInput(self.x);
-        end
-        
-        function testZeroTileY(self)
-            self.y = 0;
-            self.checkInvalidTileInput(self.x, self.y);
-        end
-        
-        function testOversizedTileY(self)
-            self.y = self.sizeY + 1;
-            self.checkInvalidTileInput(self.x, self.y);
-        end
-        
-        function testZeroTileWidth(self)
-            self.width = 0;
-            self.checkInvalidTileInput(self.x, self.y, self.width);
-        end
-        
-        function testOversizedTileWidth(self)
-            self.width = self.sizeX + 1;
-            self.checkInvalidTileInput(self.x, self.y, self.width);
-        end
-        
-        function testOversizedTileWidth2(self)
-            self.x = 2;
-            self.width = self.sizeX;
-            self.checkInvalidTileInput(self.x, self.y, self.width);
-        end
-        
-        function testZeroTileHeight(self)
-            self.height = 0;
-            self.checkInvalidTileInput(self.x, self.y, self.width, self.height);
-        end
-        
-        function testOversizedTileHeight(self)
-            self.height = self.sizeY + 1;
-            self.checkInvalidTileInput(self.x, self.y, self.width, self.height);
-        end
-        
-        function testOversizedTileHeight2(self)
-            self.y = 2;
-            self.height = self.sizeY;
-            self.checkInvalidTileInput(self.x, self.y, self.width, self.height);
-        end
-        
+
         % Pixel type tests
         function checkPixelsType(self, pixelsType)
             self.reader.setId([pixelsType '-test&pixelType=' pixelsType '.fake']);
             I = bfGetPlane(self.reader, self.iPlane);
             if strcmp(pixelsType, 'float')
-                assertEqual(class(I), 'single');
+                self.assertEqual(class(I), 'single');
             else
-                assertEqual(class(I), pixelsType);
+                self.assertEqual(class(I), pixelsType);
             end
         end
-        
+    end
+
+
+    methods (Test)
+        % Input check tests
+        function testNoInput(self)
+            self.assertError(@() bfGetPlane(), 'MATLAB:minrhs');
+        end
+
+        function testReaderClass(self)
+            self.assertError(@() bfGetPlane([]),...
+                'MATLAB:InputParser:ArgumentFailedValidation');
+        end
+
+        function testInvalidReader(self)
+            self.reader.close();
+            self.assertError(@() bfGetPlane(self.reader),...
+                'MATLAB:InputParser:ArgumentFailedValidation');
+        end
+
+        function testNoInputPlane(self)
+            f = @() bfGetPlane(self.reader);
+            self.assertError(f, 'MATLAB:InputParser:notEnoughInputs');
+        end
+
+        function testZeroPlane(self)
+            self.assertError(@() bfGetPlane(self.reader, 0),...
+                'MATLAB:InputParser:ArgumentFailedValidation');
+        end
+
+        function testOversizedPlaneIndex(self)
+            nmax = self.reader.getImageCount();
+            self.assertError(@() bfGetPlane(self.reader, nmax + 1),...
+                'MATLAB:InputParser:ArgumentFailedValidation');
+        end
+
+        function testPlaneIndexArray(self)
+            self.assertError(@() bfGetPlane(self.reader, [1 1]),...
+                'MATLAB:InputParser:ArgumentFailedValidation');
+        end
+
+        function testZeroTileX(self)
+            self.x = 0;
+            self.checkInvalidTileInput(self.x)
+        end
+
+        function testOversizedTileX(self)
+            self.x = self.sizeX + 1;
+            self.checkInvalidTileInput(self.x);
+        end
+
+        function testZeroTileY(self)
+            self.y = 0;
+            self.checkInvalidTileInput(self.x, self.y);
+        end
+
+        function testOversizedTileY(self)
+            self.y = self.sizeY + 1;
+            self.checkInvalidTileInput(self.x, self.y);
+        end
+
+        function testZeroTileWidth(self)
+            self.width = 0;
+            self.checkInvalidTileInput(self.x, self.y, self.width);
+        end
+
+        function testOversizedTileWidth(self)
+            self.width = self.sizeX + 1;
+            self.checkInvalidTileInput(self.x, self.y, self.width);
+        end
+
+        function testOversizedTileWidth2(self)
+            self.x = 2;
+            self.width = self.sizeX;
+            self.checkInvalidTileInput(self.x, self.y, self.width);
+        end
+
+        function testZeroTileHeight(self)
+            self.height = 0;
+            self.checkInvalidTileInput(self.x, self.y, self.width, self.height);
+        end
+
+        function testOversizedTileHeight(self)
+            self.height = self.sizeY + 1;
+            self.checkInvalidTileInput(self.x, self.y, self.width, self.height);
+        end
+
+        function testOversizedTileHeight2(self)
+            self.y = 2;
+            self.height = self.sizeY;
+            self.checkInvalidTileInput(self.x, self.y, self.width, self.height);
+        end
+
         function testINT8(self)
             self.checkPixelsType('int8');
         end
@@ -189,39 +189,39 @@ classdef TestBfGetPlane < ReaderTest
         function testDOUBLE(self)
             self.checkPixelsType('double');
         end
-        
+
         % Dimension size tests
         function testSizeX(self)
             self.sizeX = 200;
             self.reader.setId(['sizeX-test&sizeX=' num2str(self.sizeX) '.fake']);
             I = bfGetPlane(self.reader, self.iPlane);
-            assertEqual(size(I, 2), self.sizeX);
-            assertEqual(size(I, 1), self.sizeY);
+            self.assertEqual(size(I, 2), self.sizeX);
+            self.assertEqual(size(I, 1), self.sizeY);
         end
-        
+
         function testSizeY(self)
             self.sizeY = 200;
             self.reader.setId(['sizeY-test&sizeY=' num2str(self.sizeY) '.fake']);
             I = bfGetPlane(self.reader, self.iPlane);
-            assertEqual(size(I, 2), self.sizeX);
-            assertEqual(size(I, 1), self.sizeY);
+            self.assertEqual(size(I, 2), self.sizeX);
+            self.assertEqual(size(I, 1), self.sizeY);
         end
-        
+
         % Tile tests
         function checkTile(self)
             % Retrieve full plane and tile
             I = bfGetPlane(self.reader, self.iPlane);
             I2 = bfGetPlane(self.reader, self.iPlane, self.x, self.y,...
                 self.width, self.height);
-            
-            assertEqual(I2, I(self.y : self.y + self.height - 1,...
+
+            self.assertEqual(I2, I(self.y : self.y + self.height - 1,...
                 self.x : self.x + self.width - 1));
         end
-        
+
         function testFullTile(self)
             self.checkTile()
         end
-        
+
         function testSquareTile(self)
             self.x = self.sizeX / 4;
             self.y = self.sizeY / 4;
@@ -229,7 +229,7 @@ classdef TestBfGetPlane < ReaderTest
             self.height = self.sizeY / 2;
             self.checkTile()
         end
-        
+
         function testRectangularTile(self)
             self.x = 1;
             self.y = self.sizeY / 4;
@@ -237,7 +237,7 @@ classdef TestBfGetPlane < ReaderTest
             self.height = self.sizeY / 2;
             self.checkTile()
         end
-        
+
         function testSingleTile(self)
             self.x = self.sizeX / 2;
             self.y = self.sizeY / 4;
@@ -245,7 +245,7 @@ classdef TestBfGetPlane < ReaderTest
             self.height = 1;
             self.checkTile()
         end
-        
+
         function testRectangularImageTile(self)
             self.sizeX = 100;
             self.reader.setId(['test&sizeX=' num2str(self.sizeX) '.fake']);
@@ -254,7 +254,7 @@ classdef TestBfGetPlane < ReaderTest
             self.width = 100;
             self.checkTile()
         end
-        
+
         function testRectangularImageTile2(self)
             self.sizeY = 100;
             self.reader.setId(['test&sizeY=' num2str(self.sizeY) '.fake']);
@@ -263,24 +263,24 @@ classdef TestBfGetPlane < ReaderTest
             self.height = 100;
             self.checkTile()
         end
-               
+
         function testJavaMethod(self)
             pixelType = self.reader.getPixelType();
-            
+
             self.bpp = javaMethod('getBytesPerPixel', 'loci.formats.FormatTools', pixelType);
             self.fp = javaMethod('isFloatingPoint', 'loci.formats.FormatTools', pixelType);
             self.sgn = javaMethod('isSigned', 'loci.formats.FormatTools', pixelType);
-            
+
             bpp = loci.formats.FormatTools.getBytesPerPixel(pixelType);
             fp = loci.formats.FormatTools.isFloatingPoint(pixelType);
             sgn = loci.formats.FormatTools.isSigned(pixelType);
-            
-            assertEqual(self.bpp, bpp);
-            assertEqual(self.fp,fp);
-            assertEqual(self.sgn,sgn);
-            
+
+            self.assertEqual(self.bpp, bpp);
+            self.assertEqual(self.fp,fp);
+            self.assertEqual(self.sgn,sgn);
+
         end
 
-        
+
     end
 end

--- a/test/TestBfGetReader.m
+++ b/test/TestBfGetReader.m
@@ -26,46 +26,52 @@
 % 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 classdef TestBfGetReader < ReaderTest
-    
+
     methods
-        function self = TestBfGetReader(name)
-            self = self@ReaderTest(name);
+        % Pixel type tests
+        function checkPixelsType(self, type)
+            self.reader = bfGetReader([type '-test&pixelType=' type '.fake']);
+            pixelType = self.reader.getPixelType();
+            class = char(loci.formats.FormatTools.getPixelTypeString(pixelType));
+            self.assertEqual(class, type);
         end
-        
+    end
+
+    methods (Test)
         % Input check tests
         function testInputClass(self)
-            assertExceptionThrown(@() bfGetReader(0),...
+            self.assertError(@() bfGetReader(0),...
                 'MATLAB:InputParser:ArgumentFailedValidation');
         end
-        
+
         function testNoInput(self)
             self.reader = bfGetReader();
-            assertTrue(isa(self.reader, 'loci.formats.ReaderWrapper'));
-            assertTrue(isempty(self.reader.getCurrentFile()));
+            self.assertTrue(isa(self.reader, 'loci.formats.ReaderWrapper'));
+            self.assertTrue(isempty(self.reader.getCurrentFile()));
         end
-        
+
         function testEmptyInput(self)
             self.reader = bfGetReader('');
-            assertTrue(isa(self.reader, 'loci.formats.ReaderWrapper'));
-            assertTrue(isempty(self.reader.getCurrentFile()));
+            self.assertTrue(isa(self.reader, 'loci.formats.ReaderWrapper'));
+            self.assertTrue(isempty(self.reader.getCurrentFile()));
         end
-        
+
         function testFakeInput(self)
             self.reader = bfGetReader('test.fake');
-            assertTrue(isa(self.reader, 'loci.formats.ReaderWrapper'));
-            assertEqual(char(self.reader.getCurrentFile()), 'test.fake');
+            self.assertTrue(isa(self.reader, 'loci.formats.ReaderWrapper'));
+            self.assertEqual(char(self.reader.getCurrentFile()), 'test.fake');
         end
-        
+
         function testNonExistingInput(self)
-            assertExceptionThrown(@() bfGetReader('nonexistingfile'),...
+            self.assertError(@() bfGetReader('nonexistingfile'),...
                 'bfGetReader:FileNotFound');
         end
-        
+
         function testFormatTypeInput(self)
             self.reader = bfGetReader('test.fake');
-            assertEqual(char(self.reader.getFormat),'Simulated data');
+            self.assertEqual(char(self.reader.getFormat),'Simulated data');
         end
-        
+
         function testFileInput(self)
             % Create fake file
             mkdir(self.tmpdir);
@@ -74,18 +80,10 @@ classdef TestBfGetReader < ReaderTest
             fclose(fid);
             self.reader = bfGetReader(filepath);
             rmdir(self.tmpdir, 's');
-            assertTrue(isa(self.reader, 'loci.formats.ReaderWrapper'));
-            assertEqual(char(self.reader.getCurrentFile()), filepath);
+            self.assertTrue(isa(self.reader, 'loci.formats.ReaderWrapper'));
+            self.assertEqual(char(self.reader.getCurrentFile()), filepath);
         end
-        
-        % Pixel type tests
-        function checkPixelsType(self, type)
-            self.reader = bfGetReader([type '-test&pixelType=' type '.fake']);
-            pixelType = self.reader.getPixelType();
-            class = char(loci.formats.FormatTools.getPixelTypeString(pixelType));
-            assertEqual(class, type);
-        end
-        
+
         function testINT8(self)
             self.checkPixelsType('int8');
         end
@@ -110,127 +108,127 @@ classdef TestBfGetReader < ReaderTest
         function testDOUBLE(self)
             self.checkPixelsType('double');
         end
-        
+
         % Dimension size tests
         function testSizeX(self)
             sizeX = 200;
             self.reader = bfGetReader(['sizeX-test&sizeX=' num2str(sizeX) '.fake']);
-            assertEqual(self.reader.getSizeX(), sizeX);
+            self.assertEqual(self.reader.getSizeX(), sizeX);
         end
-        
+
         function testSizeY(self)
             sizeY = 200;
             self.reader = bfGetReader(['sizeY-test&sizeY=' num2str(sizeY) '.fake']);
-            assertEqual(self.reader.getSizeY(), sizeY);
+            self.assertEqual(self.reader.getSizeY(), sizeY);
         end
-        
+
         function testSizeZ(self)
             sizeZ = 200;
             self.reader = bfGetReader(['sizeZ-test&sizeZ=' num2str(sizeZ) '.fake']);
-            assertEqual(self.reader.getSizeZ(), sizeZ);
+            self.assertEqual(self.reader.getSizeZ(), sizeZ);
         end
-        
+
         function testSizeC(self)
             sizeC = 200;
             self.reader = bfGetReader(['sizeC-test&sizeC=' num2str(sizeC) '.fake']);
-            assertEqual(self.reader.getSizeC(), sizeC);
+            self.assertEqual(self.reader.getSizeC(), sizeC);
         end
-        
+
         function testSizeT(self)
             sizeT = 200;
             self.reader = bfGetReader(['sizeT-test&sizeT=' num2str(sizeT) '.fake']);
-            assertEqual(self.reader.getSizeT(), sizeT);
+            self.assertEqual(self.reader.getSizeT(), sizeT);
         end
-        
+
         % Endianness tests
         function testLittleEndian(self)
             self.reader = bfGetReader('little-test&little=true.fake');
-            assertTrue(self.reader.isLittleEndian());
+            self.assertTrue(self.reader.isLittleEndian());
         end
-        
+
         function testBigEndian(self)
             self.reader = bfGetReader('bigendian-test&little=false.fake');
-            assertFalse(self.reader.isLittleEndian());
+            self.assertFalse(self.reader.isLittleEndian());
         end
-        
+
         % Series tests
         function testMonoSeries(self)
             nSeries = 1;
             self.reader = bfGetReader(['series-test&series=' num2str(nSeries) '.fake']);
-            assertEqual(self.reader.getSeriesCount(), nSeries);
+            self.assertEqual(self.reader.getSeriesCount(), nSeries);
         end
-        
+
         function testMultiSeries(self)
             nSeries = 10;
             self.reader = bfGetReader(['series-test&series=' num2str(nSeries) '.fake']);
-            assertEqual(self.reader.getSeriesCount(), nSeries);
+            self.assertEqual(self.reader.getSeriesCount(), nSeries);
         end
-        
+
         function testInterleaved(self)
             self.reader = bfGetReader('interleaved-test&interleaved=true.fake');
-            assertTrue(self.reader.isInterleaved());
+            self.assertTrue(self.reader.isInterleaved());
         end
-        
+
         function testNoInterleaved(self)
             self.reader = bfGetReader('interleaved-test&interleaved=false.fake');
-            assertFalse(self.reader.isInterleaved());
+            self.assertFalse(self.reader.isInterleaved());
         end
-        
+
         function testGetPixelsPhysicalSizeX(self)
             self.reader = bfGetReader('pixelSize-test&physicalSizeX=.3.fake');
             metadata = self.reader.getMetadataStore();
             physicalSizeX = metadata.getPixelsPhysicalSizeX(0);
-            assertFalse(isempty(physicalSizeX));
-            assertEqual(physicalSizeX.value().doubleValue(), .3);
-            assertEqual(char(physicalSizeX.unit().getSymbol()), 'µm');
-            assertElementsAlmostEqual(physicalSizeX.value(ome.units.UNITS.NANOMETER).doubleValue(), 300.0);
+            self.assertFalse(isempty(physicalSizeX));
+            self.assertEqual(physicalSizeX.value().doubleValue(), .3);
+            self.assertEqual(char(physicalSizeX.unit().getSymbol()), 'Âµm');
+            self.assertEqual(physicalSizeX.value(ome.units.UNITS.NANOMETER).doubleValue(), 300.0, 'absTol', 1e-4);
         end
-        
+
         function testGetPixelsPhysicalSizeY(self)
             self.reader = bfGetReader('pixelSize-test&physicalSizeY=.3.fake');
             metadata = self.reader.getMetadataStore();
             physicalSizeY = metadata.getPixelsPhysicalSizeY(0);
-            assertFalse(isempty(physicalSizeY));
-            assertEqual(physicalSizeY.value().doubleValue(), .3);
-            assertEqual(char(physicalSizeY.unit().getSymbol()), 'µm');
-            assertElementsAlmostEqual(physicalSizeY.value(ome.units.UNITS.NANOMETER).doubleValue(), 300.0);
+            self.assertFalse(isempty(physicalSizeY));
+            self.assertEqual(physicalSizeY.value().doubleValue(), .3);
+            self.assertEqual(char(physicalSizeY.unit().getSymbol()), 'Âµm');
+            self.assertEqual(physicalSizeY.value(ome.units.UNITS.NANOMETER).doubleValue(), 300.0, 'absTol', 1e-4);
         end
-        
+
         function testGetPixelsPhysicalSizeZ(self)
             self.reader = bfGetReader('pixelSize-test&physicalSizeZ=.3.fake');
             metadata = self.reader.getMetadataStore();
             physicalSizeZ = metadata.getPixelsPhysicalSizeZ(0);
-            assertFalse(isempty(physicalSizeZ));
-            assertEqual(physicalSizeZ.value().doubleValue(), .3);
-            assertEqual(char(physicalSizeZ.unit().getSymbol()), 'µm');
-            assertElementsAlmostEqual(physicalSizeZ.value(ome.units.UNITS.NANOMETER).doubleValue(), 300.0);
+            self.assertFalse(isempty(physicalSizeZ));
+            self.assertEqual(physicalSizeZ.value().doubleValue(), .3);
+            self.assertEqual(char(physicalSizeZ.unit().getSymbol()), 'Âµm');
+            self.assertEqual(physicalSizeZ.value(ome.units.UNITS.NANOMETER).doubleValue(), 300.0, 'absTol', 1e-4);
         end
-        
+
         function testJavaMethod(self)
             self.reader = loci.formats.ChannelFiller();
             self.reader = loci.formats.ChannelSeparator(self.reader);
-            
+
             reader = javaObject('loci.formats.ChannelSeparator', ...
                 javaObject('loci.formats.ChannelFiller'));
-            assertEqual(self.reader.getClass(),reader.getClass());
-            
+            self.assertEqual(self.reader.getClass(),reader.getClass());
+
             OMEXMLService = loci.formats.services.OMEXMLServiceImpl();
             OMEXMLService1 = javaObject('loci.formats.services.OMEXMLServiceImpl');
-            assertEqual(OMEXMLService.getClass(),OMEXMLService1.getClass());
-            
+            self.assertEqual(OMEXMLService.getClass(),OMEXMLService1.getClass());
+
             self.reader.setMetadataStore(OMEXMLService1.createOMEXMLMetadata());
         end
-        
+
         %Test Default Thumb Size
         function testThumbSizeX(self)
             self.reader = bfGetReader('test.fake');
-            assertEqual(self.reader.getThumbSizeX(),128);
+            self.assertEqual(self.reader.getThumbSizeX(),128);
         end
-        
+
         function testThumbSizeY(self)
             self.reader = bfGetReader('test.fake');
-            assertEqual(self.reader.getThumbSizeY(),128);
+            self.assertEqual(self.reader.getThumbSizeY(),128);
         end
-       
+
     end
 end

--- a/test/TestBfInitLogging.m
+++ b/test/TestBfInitLogging.m
@@ -27,98 +27,101 @@
 
 
 classdef TestBfInitLogging < TestBfMatlab
-    
+
     properties
         root
     end
-    
-    methods
-        function self = TestBfInitLogging(name)
-            self = self@TestBfMatlab(name);
+
+    methods (TestMethodSetup)
+        function InitLogging(self)
+            % WIP: Is this strictly necessary?
+            javaaddpath(self.jarPath);
             import org.apache.log4j.Logger;
             self.root = Logger.getRootLogger();
         end
-        
+    end
+
+    methods (Test)
         function disableLogging(self)
             self.root.removeAllAppenders();
             bfCheckJavaPath();
-            assertFalse(loci.common.DebugTools.isEnabled());
+            self.assertFalse(loci.common.DebugTools.isEnabled());
         end
-        
+
         function testDefault(self)
             self.disableLogging();
             bfInitLogging();
-            assertTrue(loci.common.DebugTools.isEnabled());
-            assertEqual(char(self.root.getLevel.toString()), 'WARN');
+            self.assertTrue(loci.common.DebugTools.isEnabled());
+            self.assertEqual(char(self.root.getLevel.toString()), 'WARN');
             bfInitLogging('INFO');
-            assertTrue(loci.common.DebugTools.isEnabled());
-            assertEqual(char(self.root.getLevel.toString()), 'WARN');
+            self.assertTrue(loci.common.DebugTools.isEnabled());
+            self.assertEqual(char(self.root.getLevel.toString()), 'WARN');
         end
-        
+
         function testALL(self)
             self.disableLogging();
             bfInitLogging('ALL');
-            assertTrue(loci.common.DebugTools.isEnabled());
-            assertEqual(char(self.root.getLevel.toString()), 'ALL');
+            self.assertTrue(loci.common.DebugTools.isEnabled());
+            self.assertEqual(char(self.root.getLevel.toString()), 'ALL');
         end
-        
+
         function testERROR(self)
             self.disableLogging();
             bfInitLogging('ERROR');
-            assertTrue(loci.common.DebugTools.isEnabled());
-            assertEqual(char(self.root.getLevel.toString()), 'ERROR');
+            self.assertTrue(loci.common.DebugTools.isEnabled());
+            self.assertEqual(char(self.root.getLevel.toString()), 'ERROR');
         end
-        
+
         function testDEBUG(self)
             self.disableLogging();
             bfInitLogging('DEBUG');
-            assertTrue(loci.common.DebugTools.isEnabled());
-            assertEqual(char(self.root.getLevel.toString()), 'DEBUG');
+            self.assertTrue(loci.common.DebugTools.isEnabled());
+            self.assertEqual(char(self.root.getLevel.toString()), 'DEBUG');
         end
-        
+
         function testINFO(self)
             self.disableLogging();
             bfInitLogging('INFO');
-            assertTrue(loci.common.DebugTools.isEnabled());
-            assertEqual(char(self.root.getLevel.toString()), 'INFO');
+            self.assertTrue(loci.common.DebugTools.isEnabled());
+            self.assertEqual(char(self.root.getLevel.toString()), 'INFO');
         end
-        
+
         function testFATAL(self)
             self.disableLogging();
             bfInitLogging('FATAL');
-            assertTrue(loci.common.DebugTools.isEnabled());
-            assertEqual(char(self.root.getLevel.toString()), 'FATAL');
+            self.assertTrue(loci.common.DebugTools.isEnabled());
+            self.assertEqual(char(self.root.getLevel.toString()), 'FATAL');
         end
-        
+
         function testOFF(self)
             self.disableLogging();
             bfInitLogging('OFF');
-            assertTrue(loci.common.DebugTools.isEnabled());
-            assertEqual(char(self.root.getLevel.toString()), 'OFF');
+            self.assertTrue(loci.common.DebugTools.isEnabled());
+            self.assertEqual(char(self.root.getLevel.toString()), 'OFF');
         end
-        
+
         function testTRACE(self)
             self.disableLogging();
             bfInitLogging('TRACE');
-            assertTrue(loci.common.DebugTools.isEnabled());
-            assertEqual(char(self.root.getLevel.toString()), 'TRACE');
+            self.assertTrue(loci.common.DebugTools.isEnabled());
+            self.assertEqual(char(self.root.getLevel.toString()), 'TRACE');
         end
-        
+
         function testWARN(self)
             self.disableLogging();
             bfInitLogging('WARN');
-            assertTrue(loci.common.DebugTools.isEnabled());
-            assertEqual(char(self.root.getLevel.toString()), 'WARN');
+            self.assertTrue(loci.common.DebugTools.isEnabled());
+            self.assertEqual(char(self.root.getLevel.toString()), 'WARN');
         end
 
         function testSetRootLevel(self)
             self.disableLogging();
             loci.common.DebugTools.enableLogging();
-            assertTrue(loci.common.DebugTools.isEnabled());
+            self.assertTrue(loci.common.DebugTools.isEnabled());
             loci.common.DebugTools.setRootLevel('INFO');
-            assertEqual(char(self.root.getLevel.toString()), 'INFO');
+            self.assertEqual(char(self.root.getLevel.toString()), 'INFO');
             loci.common.DebugTools.setRootLevel('DEBUG');
-            assertEqual(char(self.root.getLevel.toString()), 'DEBUG');
+            self.assertEqual(char(self.root.getLevel.toString()), 'DEBUG');
         end
     end
 end

--- a/test/TestBfMatlab.m
+++ b/test/TestBfMatlab.m
@@ -25,34 +25,32 @@
 % with this program; if not, write to the Free Software Foundation, Inc.,
 % 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
-classdef TestBfMatlab < TestCase
-    
+classdef TestBfMatlab < matlab.unittest.TestCase
+
     properties
         jarPath
         tmpdir
     end
-    
-    methods
-        function self = TestBfMatlab(name)
-            self = self@TestCase(name);
-        end
-        
-        function setUp(self)
+
+    methods (TestMethodSetup)
+        function BFTestSetUp(self)
             % Get path to Bio-Formats JAR file (assuming it is in Matlab path)
             self.jarPath = which('bioformats_package.jar');
             assert(~isempty(self.jarPath));
-            
+
             % Remove Bio-Formats JAR file from dynamic class path
             if ismember(self.jarPath,javaclasspath('-dynamic'))
                 javarmpath(self.jarPath);
             end
-            
+
             java_tmpdir = char(java.lang.System.getProperty('java.io.tmpdir'));
             uuid = char(java.util.UUID.randomUUID().toString());
             self.tmpdir = fullfile(java_tmpdir, uuid);
         end
-        
-        function tearDown(self)
+    end
+
+    methods (TestMethodTeardown)
+        function BFTestTearDown(self)
             % Remove  Bio-Formats JAR file from dynamic class path
             if ismember(self.jarPath,javaclasspath('-dynamic'))
                 javarmpath(self.jarPath);

--- a/test/TestBfMatlab.m
+++ b/test/TestBfMatlab.m
@@ -34,6 +34,10 @@ classdef TestBfMatlab < matlab.unittest.TestCase
 
     methods (TestMethodSetup)
         function BFTestSetUp(self)
+            % Disable upgrade check
+            javaMethod('setProperty', 'java.lang.System', ...
+            'bioformats_can_do_upgrade_check', 'false');
+
             % Get path to Bio-Formats JAR file (assuming it is in Matlab path)
             self.jarPath = which('bioformats_package.jar');
             assert(~isempty(self.jarPath));

--- a/test/TestBfUpgradeCheck.m
+++ b/test/TestBfUpgradeCheck.m
@@ -26,29 +26,26 @@
 % 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 classdef TestBfUpgradeCheck < ReaderTest
-    
+
     properties
         upgrader
     end
-    
-    methods
-        
-        function self = TestBfUpgradeCheck(name)
-            self = self@ReaderTest(name);
-        end
-        
-        function tearDown(self)
+
+
+    methods (TestMethodTeardown)
+        function UpgradeTearDown(self)
             self.upgrader = [];
             upgrader = [];
-            tearDown@ReaderTest(self);
         end
-        
+    end
+
+    methods (Test)
         function testJavaMethod(self)
             self.upgrader = javaObject('loci.formats.UpgradeChecker');
             upgrader = loci.formats.UpgradeChecker();
-            assertEqual( self.upgrader.getClass, upgrader.getClass);
+            self.assertEqual( self.upgrader.getClass, upgrader.getClass);
         end
-        
+
     end
-    
+
 end

--- a/test/TestBfopen.m
+++ b/test/TestBfopen.m
@@ -26,7 +26,7 @@
 % 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 classdef TestBfopen < ReaderTest
-    
+
     properties
         filepath
         data
@@ -38,25 +38,22 @@ classdef TestBfopen < ReaderTest
         y = 10;
         bpp
     end
-    
-    methods
-        function self = TestBfopen(name)
-            self = self@ReaderTest(name);
-        end
-        
-        function tearDown(self)
+
+    methods (TestMethodTeardown)
+        function BfopenTearDown(self)
             if exist(self.tmpdir, 'dir') == 7, rmdir(self.tmpdir, 's'); end
             self.data = [];
-            tearDown@ReaderTest(self);
         end
-        
+    end
+
+    methods
         function checkFake(self, fakefilename)
             % Create fake file
             mkdir(self.tmpdir);
             self.filepath = fullfile(self.tmpdir, fakefilename);
             fid = fopen(self.filepath, 'w+');
             fclose(fid);
-            
+
             for flag = 1:2
                 self.flag = flag;
                 % Read fake file using bfopen
@@ -67,88 +64,90 @@ classdef TestBfopen < ReaderTest
                 elseif (self.flag == 2)
                     self.data = bfopen(self.filepath,self.x,self.y,self.width,self.height);
                 end
-                
+
                 % Test dimensions of bfopen output and core metadata
                 nPlanes = self.sizeZ * self.sizeC * self.sizeT;
-                assertEqual(size(self.data), [self.nSeries 4]);
+                self.assertEqual(size(self.data), [self.nSeries 4]);
                 for i = 1 : self.nSeries
-                    assertEqual(size(self.data{i, 1}), [nPlanes 2]);
+                    self.assertEqual(size(self.data{i, 1}), [nPlanes 2]);
                     m = self.data{i,4};
                     TileSize = size(self.data{1,1}{1,1});
-                    assertEqual(m.getImageCount(), self.nSeries);
-                    assertEqual(m.getPixelsSizeZ(i-1).getValue(), self.sizeZ);
-                    assertEqual(m.getPixelsSizeC(i-1).getValue(), self.sizeC);
-                    assertEqual(m.getPixelsSizeT(i-1).getValue(), self.sizeT);
-                    assertEqual(m.getPixelsSizeX(i-1).getValue(), self.sizeX);
-                    assertEqual(m.getPixelsSizeY(i-1).getValue(), self.sizeY);
-                    assertEqual(TileSize(1), self.x);
-                    assertEqual(TileSize(2), self.y);
-                    
+                    self.assertEqual(m.getImageCount(), self.nSeries);
+                    self.assertEqual(m.getPixelsSizeZ(i-1).getValue(), self.sizeZ);
+                    self.assertEqual(m.getPixelsSizeC(i-1).getValue(), self.sizeC);
+                    self.assertEqual(m.getPixelsSizeT(i-1).getValue(), self.sizeT);
+                    self.assertEqual(m.getPixelsSizeX(i-1).getValue(), self.sizeX);
+                    self.assertEqual(m.getPixelsSizeY(i-1).getValue(), self.sizeY);
+                    self.assertEqual(TileSize(1), self.x);
+                    self.assertEqual(TileSize(2), self.y);
+
                 end
-                
+
                 self.x = 10;
                 self.y = 10;
             end
         end
-        
+    end
+
+    methods (Test)
         % Dimension tests
         function testDefault(self)
             self.checkFake('test.fake')
         end
-        
+
         function testMultiSeries(self)
             self.nSeries = 3;
             self.checkFake(['test&series=' num2str(self.nSeries) '.fake'])
         end
-        
+
         function testSizeZ(self)
             self.sizeZ = 3;
             self.checkFake(['test&sizeZ=' num2str(self.sizeZ) '.fake'])
         end
-        
+
         function testSizeC(self)
             self.sizeC = 3;
             self.checkFake(['test&sizeC=' num2str(self.sizeC) '.fake'])
         end
-        
+
         function testSizeT(self)
             self.sizeT = 3;
             self.checkFake(['test&sizeT=' num2str(self.sizeT) '.fake'])
         end
-        
-        
+
+
         function testJavaMethod(self)
             logLevel = loci.common.DebugTools.enableLogging('INFO');
             logLevel1 = javaMethod('enableLogging', 'loci.common.DebugTools', 'INFO');
-            
-            assertEqual(logLevel,logLevel1);
-            
+
+            self.assertEqual(logLevel,logLevel1);
+
             self.reader = bfGetReader('test.fake', 0);
             pixelType = self.reader.getPixelType();
             self.bpp = loci.formats.FormatTools.getBytesPerPixel(pixelType);
             bpp = javaMethod('getBytesPerPixel', 'loci.formats.FormatTools', ...
                 pixelType);
-            
-            assertEqual(self.bpp,bpp);
-            
+
+            self.assertEqual(self.bpp,bpp);
+
         end
-        
+
         % Colormap tests
         function testNoColormap(self)
             self.sizeC = 3;
             self.checkFake('test&indexed=true&falseColor=false.fake');
-            assertTrue(isempty(self.data{3}{1}));
+            self.assertTrue(isempty(self.data{3}{1}));
         end
-        
+
         function test8BitColormap(self)
             self.checkFake('test&indexed=true&falseColor=true&pixelType=uint8.fake');
-            assertTrue(isa(self.data{3}{1}, 'single'));
+            self.assertTrue(isa(self.data{3}{1}, 'single'));
         end
-        
+
         function test16BitColormap(self)
             self.checkFake('test&indexed=true&falseColor=true&pixelType=uint16.fake');
-            assertTrue(isa(self.data{3}{1}, 'single'));
+            self.assertTrue(isa(self.data{3}{1}, 'single'));
         end
-        
+
     end
 end

--- a/test/TestBfsave.m
+++ b/test/TestBfsave.m
@@ -26,73 +26,90 @@
 % 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 classdef TestBfsave < ReaderTest
-    
+
     properties
         path
         I
         dimensionOrder = 'XYZCT'
     end
-    
-    methods
-        function self = TestBfsave(name)
-            self = self@ReaderTest(name);
-        end
-        
-        function setUp(self)
-            setUp@ReaderTest(self);
+
+    methods (TestMethodSetup)
+        function BfsaveSetUp(self)
             mkdir(self.tmpdir);
             self.path = fullfile(self.tmpdir, 'test.ome.tif');
         end
-        
-        function tearDown(self)
+    end
+
+    methods (TestMethodTeardown)
+        function BfsaveTearDown(self)
             if exist(self.tmpdir, 'dir') == 7, rmdir(self.tmpdir, 's'); end
-            tearDown@ReaderTest(self);
         end
-        
+    end
+
+    methods
+        % Pixel type tests
+        function checkPixelType(self, type)
+            self.I = zeros(100, 100, type);
+            bfsave(self.I, self.path);
+            self.assertEqual(imread(self.path), self.I);
+        end
+
+        % Compression type tests
+        function checkCompression(self, type, nonlossy)
+            self.reader = bfGetReader('plane.fake');
+            self.I = bfGetPlane(self.reader, 1);
+            bfsave(self.I, self.path, 'Compression', type);
+            if nonlossy
+                self.assertEqual(imread(self.path), self.I);
+            end
+        end
+
         function checkMinimalMetadata(self)
             % Check dimensions of saved ome-tiff
             self.reader = bfGetReader(self.path);
             d = size(self.I);
-            assertEqual(self.reader.getSizeX(), d(2));
-            assertEqual(self.reader.getSizeY(), d(1));
-            assertEqual(self.reader.getSizeZ(), d(self.dimensionOrder=='Z'));
-            assertEqual(self.reader.getSizeC(), d(self.dimensionOrder=='C'));
-            assertEqual(self.reader.getSizeT(), d(self.dimensionOrder=='T'));
-            assertEqual(char(self.reader.getDimensionOrder()), self.dimensionOrder);
+            self.assertEqual(self.reader.getSizeX(), d(2));
+            self.assertEqual(self.reader.getSizeY(), d(1));
+            self.assertEqual(self.reader.getSizeZ(), d(self.dimensionOrder=='Z'));
+            self.assertEqual(self.reader.getSizeC(), d(self.dimensionOrder=='C'));
+            self.assertEqual(self.reader.getSizeT(), d(self.dimensionOrder=='T'));
+            self.assertEqual(char(self.reader.getDimensionOrder()), self.dimensionOrder);
             metadataStore = self.reader.getMetadataStore();
-            assertEqual(char(metadataStore.getImageID(0)), 'Image:0');
-            assertEqual(char(metadataStore.getPixelsID(0)), 'Pixels:0');
+            self.assertEqual(char(metadataStore.getImageID(0)), 'Image:0');
+            self.assertEqual(char(metadataStore.getPixelsID(0)), 'Pixels:0');
             for i = 1 : d(self.dimensionOrder=='C')
-                assertEqual(char(metadataStore.getChannelID(0, i - 1)),...
+                self.assertEqual(char(metadataStore.getChannelID(0, i - 1)),...
                     sprintf('Channel:0:%g', i - 1));
             end
 
         end
-        
+    end
+
+    methods (Test)
         % Input check tests
         function testNoInput(self)
-            assertExceptionThrown(@() bfsave(),...
+            self.assertError(@() bfsave(),...
                 'MATLAB:InputParser:notEnoughInputs');
         end
-        
+
         function testNoOutputPath(self)
             self.I = 1;
-            assertExceptionThrown(@() bfsave(self.I),...
+            self.assertError(@() bfsave(self.I),...
                 'MATLAB:InputParser:notEnoughInputs');
         end
-        
+
         function testInvalidI(self)
             self.I = 'a';
-            assertExceptionThrown(@() bfsave(self.I, self.path),...
+            self.assertError(@() bfsave(self.I, self.path),...
                 'MATLAB:InputParser:ArgumentFailedValidation');
         end
-        
+
         function testInvalidDimensionOrder(self)
             self.I = 1;
-            assertExceptionThrown(@() bfsave(self.I, self.path, 'XY'),...
+            self.assertError(@() bfsave(self.I, self.path, 'XY'),...
                 'MATLAB:InputParser:ArgumentFailedValidation');
         end
-        
+
         % Dimension order tests
         function testDimensionOrderXYZCT(self)
             self.dimensionOrder = 'XYZCT';
@@ -100,132 +117,115 @@ classdef TestBfsave < ReaderTest
             bfsave(self.I, self.path, self.dimensionOrder);
             self.checkMinimalMetadata();
         end
-        
+
         function testDimensionOrderXYZTC(self)
             self.dimensionOrder = 'XYZTC';
             self.I = zeros(2, 3, 4, 5, 6);
             bfsave(self.I, self.path, self.dimensionOrder);
             self.checkMinimalMetadata();
         end
-        
+
         function testDimensionOrderXYCZT(self)
             self.dimensionOrder = 'XYCZT';
             self.I = zeros(2, 3, 4, 5, 6);
             bfsave(self.I, self.path, self.dimensionOrder);
             self.checkMinimalMetadata();
         end
-        
+
         function testDimensionOrderXYCTZ(self)
             self.dimensionOrder = 'XYCTZ';
             self.I = zeros(2, 3, 4, 5, 6);
             bfsave(self.I, self.path, self.dimensionOrder);
             self.checkMinimalMetadata();
         end
-        
+
         function testDimensionOrderXYTCZ(self)
             self.dimensionOrder = 'XYTCZ';
             self.I = zeros(2, 3, 4, 5, 6);
             bfsave(self.I, self.path, self.dimensionOrder);
             self.checkMinimalMetadata();
         end
-        
+
         function testDimensionOrderXYTZC(self)
             self.dimensionOrder = 'XYTZC';
             self.I = zeros(2, 3, 4, 5, 6);
             bfsave(self.I, self.path, self.dimensionOrder);
             self.checkMinimalMetadata();
         end
-        
-        % Pixel type tests
-        function checkPixelType(self, type)
-            self.I = zeros(100, 100, type);
-            bfsave(self.I, self.path);
-            assertEqual(imread(self.path), self.I);
-        end
-        
+
         function testPixelsTypeUINT8(self)
             self.checkPixelType('uint8');
         end
-        
+
         function testPixelsTypeINT8(self)
             self.checkPixelType('int8');
         end
-        
+
         function testPixelsTypeUINT16(self)
             self.checkPixelType('uint16');
         end
-        
+
         function testPixelsTypeINT16(self)
             self.checkPixelType('int16');
         end
-        
+
         function testPixelsTypeUINT32(self)
             self.checkPixelType('uint32');
         end
-        
+
         function testPixelsTypeINT32(self)
             self.checkPixelType('int32');
         end
-        
+
         function testPixelsTypeFLOAT(self)
             self.checkPixelType('single');
         end
-        
+
         function testPixelsTypeDOUBLE(self)
             self.checkPixelType('double');
         end
-        
+
         % Bytes reading tests
         function testSinglePoint(self)
             self.I = 1;
             bfsave(self.I, self.path);
-            assertEqual(imread(self.path), self.I);
+            self.assertEqual(imread(self.path), self.I);
         end
-        
+
         function testSinglePlane(self)
             self.reader = bfGetReader('plane.fake');
             self.I = bfGetPlane(self.reader, 1);
             bfsave(self.I, self.path);
-            assertEqual(imread(self.path), self.I);
+            self.assertEqual(imread(self.path), self.I);
         end
-        
-        % Compression type tests
-        function checkCompression(self, type, nonlossy)
-            self.reader = bfGetReader('plane.fake');
-            self.I = bfGetPlane(self.reader, 1);
-            bfsave(self.I, self.path, 'Compression', type);
-            if nonlossy
-                assertEqual(imread(self.path), self.I);
-            end
-        end
-        
+
         function testJPEG(self)
             self.checkCompression('JPEG', false);
         end
-        
+
         function testJPEG2000(self)
             self.checkCompression('JPEG-2000', false);
         end
-        
+
         function testJPEG2000Lossy(self)
             self.checkCompression('JPEG-2000 Lossy', false);
         end
-        
+
         function testUncompressed(self)
             self.checkCompression('Uncompressed', true);
         end
-        
+
         function testLZW(self)
             self.checkCompression('LZW', true);
         end
-        
+
         % Big-tiff test
         function testBigTiff(self)
             self.I = zeros(100, 100);
             bfsave(self.I, self.path, 'BigTiff', true);
-            assertEqual(imread(self.path), self.I);
+            self.assertEqual(imread(self.path), self.I);
         end
-        
+
         % Metadata test
         function testCreateMinimalOMEXMLMetadata(self)
             self.I = zeros(2, 3, 4, 5, 6);
@@ -233,7 +233,7 @@ classdef TestBfsave < ReaderTest
             bfsave(self.I, self.path, 'metadata', metadata);
             self.checkMinimalMetadata();
         end
-        
+
         function testAdditionalOMEXMLMetadata(self)
             self.I = zeros(2, 3, 4, 5, 6);
             metadata = createMinimalOMEXMLMetadata(self.I);
@@ -241,7 +241,7 @@ classdef TestBfsave < ReaderTest
             bfsave(self.I, self.path, 'metadata', metadata);
             self.checkMinimalMetadata();
             d = self.reader.getMetadataStore().getImageDescription(0);
-            assertEqual(char(d), 'description');
+            self.assertEqual(char(d), 'description');
         end
     end
 end

--- a/test/TestMemoizer.m
+++ b/test/TestMemoizer.m
@@ -31,25 +31,23 @@ classdef TestMemoizer < ReaderTest
         filepath
     end
 
-    methods
-        function self = TestMemoizer(name)
-            self = self@ReaderTest(name);
-        end
-
-        function setUp(self)
-            setUp@ReaderTest(self);
-
+    methods (TestMethodSetup)
+        function MemoizerSetUp(self)
             % Create fake file for testing
             mkdir(self.tmpdir);
             self.filepath = fullfile(self.tmpdir, 'test.fake');
             fid = fopen(self.filepath, 'w+');
             fclose(fid);
         end
-        function tearDown(self)
-            if exist(self.tmpdir, 'dir') == 7, rmdir(self.tmpdir, 's'); end
-            tearDown@ReaderTest(self);
-        end
+    end
 
+    methods (TestMethodTeardown)
+        function MemoizerTearDown(self)
+            if exist(self.tmpdir, 'dir') == 7, rmdir(self.tmpdir, 's'); end
+        end
+    end
+
+    methods (Test)
         function testMinimumElapsed(self)
             % Create memoizer reader with large minimum initialization
             % time
@@ -57,8 +55,8 @@ classdef TestMemoizer < ReaderTest
             self.reader.setId(self.filepath);
 
             % Check reader is not saved to memo file
-            assertFalse(self.reader.isLoadedFromMemo());
-            assertFalse(self.reader.isSavedToMemo());
+            self.assertFalse(self.reader.isLoadedFromMemo());
+            self.assertFalse(self.reader.isSavedToMemo());
             self.reader.close();
         end
 
@@ -69,8 +67,8 @@ classdef TestMemoizer < ReaderTest
             self.reader.setId(self.filepath);
 
             % Check reader has been saved to memo file
-            assertFalse(self.reader.isLoadedFromMemo());
-            assertTrue(self.reader.isSavedToMemo());
+            self.assertFalse(self.reader.isLoadedFromMemo());
+            self.assertTrue(self.reader.isSavedToMemo());
             self.reader.close();
         end
 
@@ -84,8 +82,8 @@ classdef TestMemoizer < ReaderTest
             self.reader.setId(self.filepath);
 
             % Check reader has been loaded from memo file
-            assertTrue(self.reader.isLoadedFromMemo());
-            assertFalse(self.reader.isSavedToMemo());
+            self.assertTrue(self.reader.isLoadedFromMemo());
+            self.assertFalse(self.reader.isSavedToMemo());
         end
 
         function testNewReader(self)
@@ -96,8 +94,8 @@ classdef TestMemoizer < ReaderTest
             % Construct new memoizer
             reader2 = loci.formats.Memoizer(bfGetReader(), 0);
             reader2.setId(self.filepath);
-            assertTrue(reader2.isLoadedFromMemo());
-            assertFalse(reader2.isSavedToMemo());
+            self.assertTrue(reader2.isLoadedFromMemo());
+            self.assertFalse(reader2.isSavedToMemo());
             reader2.close();
             self.reader.close()
             clear reader2
@@ -112,8 +110,8 @@ classdef TestMemoizer < ReaderTest
             for i = 1 : 4
                 r = loci.formats.Memoizer(bfGetReader(), 0);
                 r.setId(localpath);
-                assertTrue(r.isLoadedFromMemo());
-                assertFalse(r.isSavedToMemo());
+                self.assertTrue(r.isLoadedFromMemo());
+                self.assertFalse(r.isSavedToMemo());
                 r.close();
             end
         end

--- a/test/runbfxunit.m
+++ b/test/runbfxunit.m
@@ -1,0 +1,39 @@
+function []=runbfxunit(xmlfile)
+% OME Bio-Formats package for reading and converting biological file formats.
+%
+% Copyright (C) 2017 Open Microscopy Environment:
+%   - Board of Regents of the University of Wisconsin-Madison
+%   - Glencoe Software, Inc.
+%   - University of Dundee
+%
+% This program is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as
+% published by the Free Software Foundation, either version 2 of the
+% License, or (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License along
+% with this program; if not, write to the Free Software Foundation, Inc.,
+% 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+    import matlab.unittest.TestRunner
+    import matlab.unittest.TestSuite
+    import matlab.unittest.plugins.XMLPlugin
+
+    dir = fileparts(mfilename('fullpath'));
+
+    suite = TestSuite.fromFolder(dir)
+    runner = TestRunner.withNoPlugins;
+
+    p = XMLPlugin.producingJUnitFormat(xmlfile);
+
+    runner.addPlugin(p)
+    results = runner.run(suite);
+    table(results)
+
+    exit(0)
+end


### PR DESCRIPTION
Follows on from #2 and also from https://github.com/openmicroscopy/bioformats/pull/2989

Also skips upgrade checks as in https://github.com/openmicroscopy/bioformats/pull/3142

Testing: Run `mvn -P test-matlab` (with `matlab` on your `PATH`).  It will run the unit tests and display the results.  Requires a recent Matlab version (>2013).  Test results are in `target/matlab-test-results/report.xml`.

Could have some further tweaks, e.g. returning a non-zero exit status if the tests fail.  But really could use some input from a matlab person!

/cc @sbesson 